### PR TITLE
feat: 키워드 검색으로 리스트페이지에서 쓸 data 얻어오기 (dataApi-readSearchKeyword)

### DIFF
--- a/src/api/dataApi.js
+++ b/src/api/dataApi.js
@@ -9,10 +9,46 @@ const axiosInstance = axios.create({
   responseType: 'json'
 });
 
-export const readSearchKeyWord = async () => {
-  const { data } = await axiosInstance.get(`${request.getSearchKeyWord}&regionCode=KR`);
-  return data;
-};
+// 해시태그# 검색 기능 - get 키워드검색데이터 (input: keyword)
+// 필요한 정보 - 채널명, 채널썸네일이미지, 구독자수, 평균조회수, (상세페이지? -평균 좋아요수, 평균 댓글 수, 최근 or 인기 영상?)
+// TODO 채널중복걸러내기 / 날짜 한달전으로 설정
+export const readSearchKeyWord = async (keyword) => {
+  // 키워드에 따라서 q=에 넣을 값 다르게 바꾸기 ('생활'은 다르게 바꿔넣어야할거같다?)
+  // TODO categoryId 설정해주기
+  // if (keyword == "뷰티") {
+  // const videoCategoryId = 26
+  //  };
+  const params = { q: keyword }; // &q=${keyword}
+  const videoResponse = await axiosInstance.get(`${request.getSearchKeyWord}`, { params });
+
+  const videoItems = videoResponse.data.items;
+  const result = [];
+
+  // NOTE 정보들 - 전역상태관리해야할것같다 RQ 사용해야할듯 여기서 return 후?
+  for (const item of videoItems) {
+    const channelId = item.snippet.channelId;
+    const channelTitle = item.snippet.channelTitle;
+
+    // NOTE 아래부분 mainSliderDataApi 에서도 쓰이는데, 따로 빼는게 좋을지..  => but snippet도 추가
+    const channelResponse = await axiosInstance.get(`${request.getChannelSnippetStatistics}&id=${channelId}`);
+
+    const snippet = channelResponse.data.items[0].snippet;
+    const description = snippet.description; // 채널설명
+    const thumbnailUrl = snippet.thumbnails.medium.url; // 채널 썸네일 url
+
+    const statistics = channelResponse.data.items[0].statistics;
+    const initSubscriberCount = statistics.subscriberCount; // 채널 구독자수
+    const videoCount = statistics.videoCount; // 채널 총 영상수
+    const viewCount = statistics.viewCount; // 채널 총 조회수(모든 영상 조회수의 합)
+    const initAverageViewCount = viewCount / videoCount; // (일반적인) 채널 평균 조회수 (총 조회수 / 총 영상 수)
+
+    const subscriberCount = Math.round(initSubscriberCount / 10000) + '만'; // 구독자수 만 단위 반올림
+    const averageViewCount = Math.round(initAverageViewCount / 10000) + '만'; // 평균조회수 만 단위 반올림 89만6천.. => 90만
+
+    result.push({ channelTitle, description, thumbnailUrl, subscriberCount, averageViewCount });
+  }
+  return result;
+}; // 객체담긴 배열 형태로 리턴 - {채널명, 채널썸네일이미지url, 구독자수(만), 평균조회수(만)}
 
 export const readMostPopularVideos = async () => {
   const { data } = await axiosInstance.get(`${request.getMostPopularVideos}&regionCode=KR`);

--- a/src/api/mainSliderDataApi.js
+++ b/src/api/mainSliderDataApi.js
@@ -10,26 +10,28 @@ export const mainSliderDataClient = axios.create({
   responseType: 'json'
 });
 
-// 영상 썸네일 이미지
+// input: 영상id   output: 영상썸네일이미지url 및 해당 채널 정보가 담긴 객체
 export const getVideoChannelDatabyId = async (videoId) => {
   // 영상id 한번만 받아서 채널id까지 찾을 수 있으니 한번에 채널id로 연결시켜서 채널id통해 유튜버(채널)명, 구독자수 등 객체로 전달해주기
   const videoResponse = await mainSliderDataClient.get(`${request.getVideoSnippet}&id=${videoId}`);
-  const videoSnippet = videoResponse.data.items[0].snippet;
-  const channelId = videoSnippet.channelId; // 영상 id통해 채널 id 얻기
-  const channelTitle = videoSnippet.channelTitle; // 채널명 (유튜버명)
-  const thumbnailUrl = videoSnippet.thumbnails.standard.url; // 영상 썸네일이미지 url
+  // console.log(videoResponse.data);
+  const snippet = videoResponse.data.items[0].snippet;
+  const channelId = snippet.channelId; // 영상 id통해 채널 id 얻기
+  const channelTitle = snippet.channelTitle; // 채널명 (유튜버명)
+  const thumbnailUrl = snippet.thumbnails.standard.url; // 영상 썸네일이미지 url
 
   // 위의 받은 채널 id 사용
   const channelResponse = await mainSliderDataClient.get(`${request.getChannelStatistics}&id=${channelId}`);
+  // console.log(channelResponse.data);
 
-  const channelStatistics = channelResponse.data.items[0].statistics;
-  const originalSubscriberCount = channelStatistics.subscriberCount; // 채널 구독자수
-  const videoCount = channelStatistics.videoCount; // 채널 총 영상수
-  const viewCount = channelStatistics.viewCount; // 채널 총 조회수(모든 영상 조회수의 합)
-  const originalAverageViewCount = viewCount / videoCount; // (일반적인) 채널 평균 조회수 (총 조회수 / 총 영상 수)
+  const statistics = channelResponse.data.items[0].statistics;
+  const initSubscriberCount = statistics.subscriberCount; // 채널 구독자수
+  const videoCount = statistics.videoCount; // 채널 총 영상수
+  const viewCount = statistics.viewCount; // 채널 총 조회수(모든 영상 조회수의 합)
+  const initAverageViewCount = viewCount / videoCount; // (일반적인) 채널 평균 조회수 (총 조회수 / 총 영상 수)
 
-  const subscriberCount = Math.round(originalSubscriberCount / 10000) + '만'; // 구독자수 만 단위 반올림
-  const averageViewCount = Math.round(originalAverageViewCount / 10000) + '만'; // 평균조회수 만 단위 반올림 89만6천.. => 90만
+  const subscriberCount = Math.round(initSubscriberCount / 10000) + '만'; // 구독자수 만 단위 반올림
+  const averageViewCount = Math.round(initAverageViewCount / 10000) + '만'; // 평균조회수 만 단위 반올림 89만6천.. => 90만
 
   return { channelTitle, thumbnailUrl, subscriberCount, averageViewCount };
   // 채널명(유튜버명), 영상썸네일이미지url, 채널구독자수(만 단위), 채널평균조회수(만 단위)

--- a/src/api/request.js
+++ b/src/api/request.js
@@ -1,13 +1,16 @@
 const apiKey = import.meta.env.VITE_APP_YOUTUBE_API_KEY;
+const videoSnippetFields = 'items(snippet(channelId,channelTitle,thumbnails(standard)))';
+const channelStatisticsFields = 'items(statistics(subscriberCount,videoCount,viewCount))';
 
 const request = {
-  getSearchKeyWord: `/search?part=snippet&maxResults=25&q=surfing&key=${apiKey}`,
+  getSearchKeyWord: `/search?part=snippet&type=video&publishedAfter=2024-01-20T00:00:00Z&order=viewCount&maxResults=3&regionCode=KR&key=${apiKey}`, // maxResults 기능구현 후 바꾸기 (최대50으로?)
   getMostPopularVideos: `/videos?part=snippet%2CcontentDetails%2Cstatistics&chart=mostPopular&regionCode=US&key=${apiKey}`,
   getByChannelId: `/channels?part=snippet%2CcontentDetails%2Cstatistics&id=UC_x5XG1OV2P6uZZ5FSM9Ttw&key=${apiKey}`,
   getVidoeId: `/videos?part=snippet%2CcontentDetails%2Cstatistics&id=Ks-_Mh1QhMc&key=${apiKey}`,
   getI18nRegions: `/i18nRegions?part=snippet&hl=es_MX&key=${apiKey}`,
   getVideoSnippet: `/videos?part=snippet&key=${apiKey}`,
-  getChannelStatistics: `/channels?part=statistics&key=${apiKey}`
+  getChannelStatistics: `/channels?part=statistics&key=${apiKey}`,
+  getChannelSnippetStatistics: `/channels?part=snippet,statistics&key=${apiKey}`
 };
 
 export default request;

--- a/src/components/main/Main.jsx
+++ b/src/components/main/Main.jsx
@@ -3,23 +3,31 @@ import styled from 'styled-components';
 import HeaderSlider from '../sliders/HeaderSlider';
 import BodySlider from '../sliders/BodySlider';
 import { useMostPopularVideos } from '../../hooks/useMostPopularChannel';
-import { getMostPopularThumbnails } from '../../api/dataApi';
+import { getMostPopularThumbnails, readSearchKeyWord } from '../../api/dataApi';
 import Thumbnail from '../main/Thumbnail';
+import { useNavigate } from 'react-router-dom';
 
 export default function Main() {
+  const navigate = useNavigate();
   const [thumbnails, setThumbmails] = useState([]);
   const { data: videos, isLoading, isError } = useMostPopularVideos();
 
-  useEffect(() => {
-    const getThumbnails = async () => {
-      if (videos) {
-        const getFiveThumbnails = videos.slice(0, 5).map((video) => getMostPopularThumbnails(video.snippet.channelId));
-        const getOneThumbnail = await Promise.all(getFiveThumbnails);
-        setThumbmails(getOneThumbnail);
-      }
-    };
-    getThumbnails();
-  }, [videos]);
+  const keyWords = ['먹방', '여행', '생활', '운동', '뷰티', '패션'];
+
+  // useEffect(() => {
+  //   const getThumbnails = async () => {
+  //     if (videos) {
+  //       const getFiveThumbnails = videos.slice(0, 5).map((video) => getMostPopularThumbnails(video.snippet.channelId));
+  //       const getOneThumbnail = await Promise.all(getFiveThumbnails);
+  //       setThumbmails(getOneThumbnail);
+  //     }
+  //   };
+  //   getThumbnails();
+  // }, [videos]);
+
+  const handleKeyWordClick = async (keyword) => {
+    navigate(`/list/${keyword}`);
+  };
 
   if (isLoading) return <div>..Loading</div>;
 
@@ -31,12 +39,15 @@ export default function Main() {
       <MainSearch>
         <input type="search" placeholder="주제를 검색하세요." />
         <SearchKeyWord>
-          <span>#먹방</span>
-          <span>#여행</span>
+          {keyWords.map((keyword) => {
+            return <span onClick={() => handleKeyWordClick(keyword)}>#{keyword}</span>;
+          })}
+          {/* <span onClick={() => handleKeyWordClick()}>#먹방</span> */}
+          {/* <span>#여행</span>
           <span>#생활</span>
           <span>#운동</span>
           <span>#뷰티</span>
-          <span>#패션</span>
+          <span>#패션</span> */}
         </SearchKeyWord>
       </MainSearch>
       <BodySlider />

--- a/src/share/Router.jsx
+++ b/src/share/Router.jsx
@@ -11,12 +11,14 @@ const router = createBrowserRouter([
     errorElement: <Error />
   },
   {
-    path: '/list:keyword',
+    path: '/list/:keyword',
     element: <List />,
-    children: {
-      path: '/list/:keyword/:id',
-      element: <Detail />
-    }
+    children: [
+      {
+        path: ':id',
+        element: <Detail />
+      }
+    ]
   },
   {
     path: '*',

--- a/src/share/Router.jsx
+++ b/src/share/Router.jsx
@@ -2,6 +2,7 @@ import { Navigate, RouterProvider, createBrowserRouter } from 'react-router-dom'
 import Home from '../pages/Home';
 import List from '../pages/List';
 import Error from '../pages/Error';
+import Detail from '../components/detail/Detail';
 
 const router = createBrowserRouter([
   {
@@ -10,8 +11,12 @@ const router = createBrowserRouter([
     errorElement: <Error />
   },
   {
-    path: '/list',
-    element: <List />
+    path: '/list:keyword',
+    element: <List />,
+    children: {
+      path: '/list/:keyword/:id',
+      element: <Detail />
+    }
   },
   {
     path: '*',


### PR DESCRIPTION
- 메인페이지에서 해시태그#키워드 누르면 -> list 페이지로 넘어가게 함
- api-  readSearchKeyword( )  : input 키워드 들어가면,  해당 리스트의 각 채널 정보 객체 리턴

- 오타 수정